### PR TITLE
1053: Changed comment input position to top to fix keyboard overlappi…

### DIFF
--- a/components/Comments/Comments.module.scss
+++ b/components/Comments/Comments.module.scss
@@ -89,3 +89,23 @@
   font-size: 18px;
   padding: 10px;
 }
+
+.commentsInputFocused {
+  padding-top: 1rem;
+
+  & .form {
+    order: 1;
+    border-bottom: 0.5px solid black;
+    border-top: none;
+  }
+
+  & .comments-list {
+    order: 2;
+    margin-top: 0;
+  }
+
+  & .selected-comment {
+    border-bottom: 0.5px solid black;
+    border-top: none;
+  }
+}

--- a/components/Comments/Comments.tsx
+++ b/components/Comments/Comments.tsx
@@ -1,8 +1,8 @@
 import { Button, CommentSkeleton, Divider } from 'components';
 import { StorysetImage } from 'components/lib';
-import { useAuth, useClickOutside, useInfiniteScrollV2, useTheme } from 'hooks';
+import { useAuth, useClickOutside, useDevice, useInfiniteScrollV2, useTheme } from 'hooks';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { useAppDispatch, useAppSelector } from 'store';
 import { useLazyGetCommentsByArticleIdQuery } from 'store/apis';
@@ -28,13 +28,24 @@ export const Comments = (): JSX.Element => {
     query: { id },
   } = useRouter();
   const { themeColors } = useTheme();
+  const { isMobile } = useDevice();
   const isOpen = useAppSelector(getIsCommentsSidebarOpen);
-  const rootClassName = getClassName(classes['comments'], isOpen && classes['comments--open']);
+  const [isCommentFocused, setIsCommentFocused] = useState<boolean>(false);
+  const rootClassName = getClassName(
+    classes['comments'],
+    isOpen && classes['comments--open'],
+    isCommentFocused && isMobile && classes['commentsInputFocused'],
+  );
   const infiniteScrollApi = useInfiniteScrollV2<IComment>(useLazyGetCommentsByArticleIdQuery);
   const { hasMore, fetchFirstPage, fetchNextPage, list: comments, isLoading } = infiniteScrollApi;
 
+  const commentInputFocusHandle: React.FocusEventHandler<HTMLTextAreaElement> = (e): void => {
+    setIsCommentFocused(e.type === 'focus');
+  };
+
   const closeComments = useCallback(() => {
     dispatch(closeCommentsSidebar());
+    setIsCommentFocused(false);
   }, []);
 
   const [rootRef] = useClickOutside(closeComments, '[data-action="open-comments"]');
@@ -146,6 +157,7 @@ export const Comments = (): JSX.Element => {
             isBeingEdited={isBeingEdited}
             onSubmit={submitHandler}
             api={infiniteScrollApi}
+            focusHandler={commentInputFocusHandle}
           />
         ) : (
           <div>

--- a/components/Comments/components/Form/Form.tsx
+++ b/components/Comments/components/Form/Form.tsx
@@ -1,7 +1,7 @@
 import { Button, Error, Textarea } from 'components';
 import { useDevice } from 'hooks';
 import { useRouter } from 'next/router';
-import { FC, FormEvent, useCallback, useEffect } from 'react';
+import { FC, FormEvent, useCallback, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { useCreateCommentMutation, useEditCommentMutation } from 'store/apis';
 import { TSubmitFormEvent } from 'types';
@@ -103,6 +103,7 @@ export const Form: FC<IFormProps> = (props) => {
                 rows={2}
                 placeholder='Izohingizni bu yerga yozing'
                 color={isMobile ? 'dark' : 'transparent'}
+                onFocus={props.focusHandler}
                 {...register('text', {
                   required: {
                     value: true,

--- a/components/Comments/components/Form/Form.tsx
+++ b/components/Comments/components/Form/Form.tsx
@@ -1,7 +1,7 @@
 import { Button, Error, Textarea } from 'components';
 import { useDevice } from 'hooks';
 import { useRouter } from 'next/router';
-import React, { FC, FormEvent, useCallback, useEffect, useRef } from 'react';
+import { FC, FormEvent, useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useCreateCommentMutation, useEditCommentMutation } from 'store/apis';
 import { TSubmitFormEvent } from 'types';
@@ -96,6 +96,7 @@ export const Form: FC<IFormProps> = (props) => {
 
   return (
     <form className={classes.form} onSubmit={handleSubmit(submitHandler)}>
+      <input style={{ display: 'none' }} autoFocus={true} />
       {isMobile ? (
         <div>
           <div className='d-flex align-items-center'>

--- a/components/Comments/components/Form/Form.tsx
+++ b/components/Comments/components/Form/Form.tsx
@@ -1,7 +1,7 @@
 import { Button, Error, Textarea } from 'components';
 import { useDevice } from 'hooks';
 import { useRouter } from 'next/router';
-import { FC, FormEvent, useCallback, useEffect, useRef } from 'react';
+import React, { FC, FormEvent, useCallback, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { useCreateCommentMutation, useEditCommentMutation } from 'store/apis';
 import { TSubmitFormEvent } from 'types';
@@ -50,11 +50,13 @@ export const Form: FC<IFormProps> = (props) => {
   );
 
   const onChangeComment = (event: FormEvent<HTMLTextAreaElement>): void => {
-    const value = event.currentTarget.value;
-    setValue('text', value);
-    if (errors.text && value.trim()) {
+    const target = event.currentTarget as HTMLTextAreaElement;
+    setValue('text', target.value);
+    if (errors.text && target.value.trim()) {
       clearErrors('text');
     }
+    target.style.height = '0';
+    target.style.height = target.scrollHeight + 5 + 'px';
   };
 
   useEffect(() => {

--- a/components/Comments/components/Form/Form.types.ts
+++ b/components/Comments/components/Form/Form.types.ts
@@ -1,4 +1,5 @@
 import { IInfiniteScrollV2 } from 'hooks';
+import React from 'react';
 import { IComment, TSubmitFormEvent } from 'types';
 
 export interface IFormProps {
@@ -7,4 +8,5 @@ export interface IFormProps {
   selectedComment?: IComment;
   isBeingEdited?: boolean;
   api: IInfiniteScrollV2<IComment>;
+  focusHandler: React.FocusEventHandler<HTMLTextAreaElement>;
 }

--- a/components/lib/Textarea/Textarea.module.scss
+++ b/components/lib/Textarea/Textarea.module.scss
@@ -9,6 +9,9 @@
   background-color: transparent;
   color: inherit;
   outline: transparent solid 1px;
+  max-height: 120px;
+  min-height: 45px;
+  height: 45px;
 
   &--transparent {
     border: none;


### PR DESCRIPTION
Since there is no possibility to detect on-screen keyboard height on mobile devices, I could not find a way to make the input field visible above the keyboard.

Another way could be to move the input field out of the comments container, which has fixed positioning, so that input field is pushed to top by keyboard because input has a static position. However, this approach requires many other changes and may not give a desired result.

That's why I decided to move input field to the beginning of comments container. As a result, both keyboard and comments list are below input field.