### PR TITLE
code block's transparency fixed

### DIFF
--- a/styles/_editorjs.scss
+++ b/styles/_editorjs.scss
@@ -267,10 +267,11 @@
 
   .editorjs-codeFlask_Wrapper {
     border: 0.5px solid;
-    background-color: transparent;
+    background-color: var(--popover-bg);
 
     .editorjs-codeFlask_LangDisplay {
-      background-color: transparent;
+      background-color: inherit;
+      z-index: 10;
       border-top: 0.5px solid;
       border-left: 0.5px solid;
       padding: 2px 10px;
@@ -279,7 +280,7 @@
     .editorjs-codeFlask_CopyButton {
       background-color: var(--popover-bg);
       border: 0.5px solid;
-
+      z-index: 10;
       svg path {
         stroke: #ffffff;
       }


### PR DESCRIPTION
<img width="101" alt="image" src="https://github.com/Juratbek/upper_frontend/assets/81279078/a7ee52e7-0cab-4d2b-a253-839f1172151d">
